### PR TITLE
Pointwise Library

### DIFF
--- a/maple2jax/BUILD
+++ b/maple2jax/BUILD
@@ -8,6 +8,7 @@ exports_files([
     "gen_py.py",
     "build.jinja",
     "python_template.jinja",
+    "python_template_pointwise.jinja",
     "utils.py",
     "wheel.BUILD",
 ])

--- a/maple2jax/build.jinja
+++ b/maple2jax/build.jinja
@@ -4,7 +4,9 @@ py_binary(
     name = "gen_py",
     srcs = ["gen_py.py"],
     visibility = ["//visibility:public"],
-    deps = ["@maple2jax//jax_xc/libxc"],
+    deps = [
+        "@maple2jax//jax_xc/libxc",
+    ],
 )
 
 py_library(
@@ -16,17 +18,29 @@ py_library(
 
 genrule(
     name = "gen_functionals",
-    outs = ["functionals.py"],
-    cmd = "$(execpath :gen_py) --output $@ --template $(execpath :python_template.jinja)",
+    outs = ["functionals.py", "pointwise_functionals.py"],
+    cmd = "$(execpath :gen_py) --output $(execpath :functionals.py) --pointwise_output $(execpath :pointwise_functionals.py) --template $(execpath :python_template.jinja) --pointwise_template $(execpath :python_template_pointwise.jinja)",
     tools = [
         ":gen_py",
         ":python_template.jinja",
+        ":python_template_pointwise.jinja"
     ],
 )
 
 py_library(
     name = "functionals",
-    srcs = [":gen_functionals"],
+    srcs = ["functionals.py"],
+    deps = [
+        ":utils",
+        "@maple2jax//jax_xc/libxc",
+        "@maple2jax//jax_xc/impl",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "pointwise_functionals",
+    srcs = ["pointwise_functionals.py"],
     deps = [
         ":utils",
         "@maple2jax//jax_xc/libxc",
@@ -38,6 +52,6 @@ py_library(
 py_library(
     name = "jax_xc",
     srcs = ["__init__.py"],
-    deps = [":functionals"],
+    deps = [":functionals", ":pointwise_functionals"],
     visibility = ["//visibility:public"],
 )

--- a/maple2jax/gen_py.py
+++ b/maple2jax/gen_py.py
@@ -15,6 +15,8 @@ from jax_xc.libxc import libxc
 FLAGS = flags.FLAGS
 flags.DEFINE_string("output", None, "output py file")
 flags.DEFINE_string("template", None, "template file")
+flags.DEFINE_string("pointwise_output", None, "pointwise output py file")
+flags.DEFINE_string("pointwise_template", None, "pointwise template file")
 
 
 def post_process(param_name):
@@ -83,6 +85,12 @@ def main(_):
     py_template = Template(f.read(), trim_blocks=True, lstrip_blocks=True)
     py_code = py_template.render(functionals=functionals, zip=zip)
     with open(FLAGS.output, "w") as out:
+      out.write(py_code)
+
+  with open(FLAGS.pointwise_template, "r") as f:
+    py_template = Template(f.read(), trim_blocks=True, lstrip_blocks=True)
+    py_code = py_template.render(functionals=functionals, zip=zip)
+    with open(FLAGS.pointwise_output, "w") as out:
       out.write(py_code)
 
 

--- a/maple2jax/maple2jax.bzl
+++ b/maple2jax/maple2jax.bzl
@@ -78,6 +78,7 @@ def _impl(rctx):
     rctx.symlink(Label("//maple2jax:gen_py.py"), "jax_xc/gen_py.py")
     rctx.symlink(Label("//maple2jax:utils.py"), "jax_xc/utils.py")
     rctx.symlink(Label("//maple2jax:python_template.jinja"), "jax_xc/python_template.jinja")
+    rctx.symlink(Label("//maple2jax:python_template_pointwise.jinja"), "jax_xc/python_template_pointwise.jinja")
     rctx.symlink(Label("//maple2jax:wheel.BUILD"), "BUILD")
 
 maple2jax_repo = repository_rule(_impl, environ = ["GITHUB_ACTIONS"])

--- a/maple2jax/python_template_pointwise.jinja
+++ b/maple2jax/python_template_pointwise.jinja
@@ -1,0 +1,177 @@
+import jax
+import jax.numpy as jnp
+import ctypes
+from collections import namedtuple
+from typing import Callable, Optional, Tuple
+from . import impl
+from .utils import get_p, rho_to_arguments, call_functional, call_functional_pointwise
+
+{% for name, ext_params, maple_name, ext_params_descriptions, info, aux_info in functionals %}
+{% for polarized in [True, False] %}
+{% if polarized %}
+def {{ name }}_pol(
+  rho0: float,
+  rho1: float,
+  {% if not (name.startswith("lda") or name.startswith("hyb_lda")) %}
+  sigma0: float,
+  sigma1: float,
+  sigma2: float,
+  {% endif %}
+  {% if name.startswith("mgga") or name.startswith("hyb_mgga") %}
+  lapl0: float,
+  lapl1: float,
+  tau0: float,
+  tau1: float,
+  {% endif %}
+{% else %}
+def {{ name }}_unpol(
+  rho: float,
+  {% if not (name.startswith("lda") or name.startswith("hyb_lda")) %}
+  sigma: float,
+  {% endif %}
+  {% if name.startswith("mgga") or name.startswith("hyb_mgga") %}
+  lapl: float,
+  tau: float,
+  {% endif %}
+{% endif %}
+{% for param_name in ext_params.keys() %}
+  {{ param_name }}: Optional[float] = None,
+{% endfor %}
+) -> float:
+  r"""
+  {% for url, doi, ref in info %}
+  {{ ref }}
+  {% if url != "" %}
+  `{{ doi }} <{{ url }}>`_
+  {% else %}
+  {{ doi }}
+  {% endif %}
+
+  {% endfor %}
+  {% if aux_info != [] %}
+  Hybrid Functionals:
+
+  {% for fn_aux_name, mix_coef in aux_info %}
+    {% if maple_name == "DEORBITALIZE" %}
+    {{ fn_aux_name }} (Mixing Coefficient is meaningless for DEORBITALIZE functional)
+    {% else %}
+    {{ fn_aux_name }} (Mixing Coefficient: {{ mix_coef }})
+    {% endif %}
+
+  {% endfor %}
+  {% endif %}
+  Parameters
+  ----------
+  {% if polarized %}
+  rho0 : float
+      Electron density of spin up.
+  rho1 : float
+      Electron density of spin down.
+  {% if not (name.startswith("lda") or name.startswith("hyb_lda")) %}
+  sigma0 : float
+      reduced gradient :math:`\sigma_0 = \nabla \rho_0 \cdot \nabla \rho_0 = |\nabla \rho_0|^2`.
+  sigma1 : float
+      reduced gradient :math:`\sigma_1 = \nabla \rho_0 \cdot \nabla \rho_1`.
+  sigma2 : float
+      reduced gradient :math:`\sigma_2 = \nabla \rho_1 \cdot \nabla \rho_1 = |\nabla \rho_1|^2`.
+  {% endif %}
+  {% if name.startswith("mgga") or name.startswith("hyb_mgga") %}
+  lapl0 : float
+      laplacian of density :math:`\tau_0 = \nabla^2 \rho_0`.
+  lapl1 : float
+      laplacian of density :math:`\tau_1 = \nabla^2 \rho_1`.
+  tau0 : float
+      the non-interacting kinetic energy density 
+      :math:`\tau_0 = \frac{1}{2} \sum_{i}|\nabla \psi_i^{0}(r)|^2`.
+  tau1 : float
+      the non-interacting kinetic energy density 
+      :math:`\tau_1 = \frac{1}{2} \sum_{i}|\nabla \psi_i^{1}(r)|^2`.
+  {% endif %}
+  {% else %}
+  rho : float
+      Electron density.
+  {% if not (name.startswith("lda") or name.startswith("hyb_lda")) %}
+  sigma : float
+      reduced gradient :math:`\sigma = \nabla \rho \cdot \nabla \rho = |\nabla \rho|^2`.
+  {% endif %}
+  {% if name.startswith("mgga") or name.startswith("hyb_mgga") %}
+  lapl : float
+      laplacian of density :math:`\tau = \nabla^2 \rho`.
+  tau : float
+      the non-interacting kinetic energy density 
+      :math:`\tau = \frac{1}{2} \sum_{i}|\nabla \psi_i(r)|^2`.
+  {% endif %}
+  {% endif %}
+{% for (param_name, param_val), param_descrip in zip(ext_params.items(), ext_params_descriptions) %}
+  {{ param_name }} : Optional[float], default: {{ param_val }}
+      {{ param_descrip }}
+{% endfor %}
+  """
+{% for param_name, value in ext_params.items() %}
+  {{ param_name }} = ({{ param_name }} or {{ value }})
+{% endfor %}
+  p = get_p("{{ name }}", {{ polarized }}, {{ ext_params.keys()|join(', ') }})
+  
+  {% if polarized %}
+  return jax.lax.cond(
+    rho0 + rho1 < p.dens_threshold,
+    lambda _: 0.,
+    {% if name.startswith("lda") or name.startswith("hyb_lda") %}
+    lambda _: call_functional_pointwise(rho0, 
+                                        rho1,
+                                        polarized={{ polarized }},
+                                        p=p,
+                                      ),
+    {% elif name.startswith("gga") or name.startswith("hyb_gga") %}
+    lambda _: call_functional_pointwise(rho0,
+                                        rho1,
+                                        sigma0,
+                                        sigma1,
+                                        sigma2,
+                                        polarized={{ polarized }},
+                                        p=p,
+                                      ),    
+    {% elif name.startswith("mgga") or name.startswith("hyb_mgga") %}
+    lambda _: call_functional_pointwise(rho0,
+                                        rho1,
+                                        sigma0,
+                                        sigma1,
+                                        sigma2,
+                                        lapl0,
+                                        lapl1,
+                                        tau0,
+                                        tau1,
+                                        polarized={{ polarized }},
+                                        p=p),
+    {% endif %}
+    operand=None,
+  )
+  {% else %}
+  return jax.lax.cond(
+    rho < p.dens_threshold,
+    lambda _: 0.,
+    {% if name.startswith("lda") or name.startswith("hyb_lda") %}
+    lambda _: call_functional_pointwise(rho, 
+                                        polarized={{ polarized }},
+                                        p=p,
+                                      ),
+    {% elif name.startswith("gga") or name.startswith("hyb_gga") %}
+    lambda _: call_functional_pointwise(rho,
+                                        sigma,
+                                        polarized={{ polarized }},
+                                        p=p,
+                                      ),    
+    {% elif name.startswith("mgga") or name.startswith("hyb_mgga") %}
+    lambda _: call_functional_pointwise(rho,
+                                        sigma,
+                                        lapl,
+                                        tau,
+                                        polarized={{ polarized }},
+                                        p=p),
+    {% endif %}
+    operand=None,
+  )
+  {% endif %}
+
+{% endfor %}
+{% endfor %}

--- a/maple2jax/wheel.BUILD
+++ b/maple2jax/wheel.BUILD
@@ -20,7 +20,7 @@ py_wheel(
         "numpy",
         "tensorflow-probability",
     ],
-    version = "0.0.3",
+    version = "0.0.4",
     deps = [
         "@maple2jax//jax_xc",
         "@maple2jax//jax_xc:functionals",

--- a/maple2jax/wheel.BUILD
+++ b/maple2jax/wheel.BUILD
@@ -24,6 +24,7 @@ py_wheel(
     deps = [
         "@maple2jax//jax_xc",
         "@maple2jax//jax_xc:functionals",
+        "@maple2jax//jax_xc:pointwise_functionals",
         "@maple2jax//jax_xc:utils",
         "@maple2jax//jax_xc/impl",
         "@maple2jax//jax_xc/libxc",


### PR DESCRIPTION
Resolves: #22 

- [ ] Update README accordingly.
- [ ] Looks like the doc is not generated for this module.

Maybe change the naming like `pointwise_functionals` to `discretized_functionals`?

```python
import jax_xc
from jax_xc import pointwise_functionals as pwf

def rho(r):
    return jnp.prod(norm.pdf(r, loc=0, scale=1))

# a grid point in 3D
r = jnp.array([0.1, 0.2, 0.3], dtype=jnp.float64)

exc = pwf.lda_x_unpol(rho(r))
print(exc)

exc = pwf.lda_x_pol(rho(r)/2, rho(r)/2)
print(exc)
```