### PR TITLE
Fix the gradient contains nan bug

### DIFF
--- a/maple2jax/impl/gen_py.py
+++ b/maple2jax/impl/gen_py.py
@@ -61,8 +61,10 @@ def main(_):
 
   with open(FLAGS.pol, "r") as pol:
     pol_code = pol.read()
+    pol_code = post_process(pol_code)
   with open(FLAGS.unpol, "r") as unpol:
     unpol_code = unpol.read()
+    unpol_code = post_process(unpol_code)
 
   with open(FLAGS.template, "r") as f:
     py_template = Template(f.read(), trim_blocks=True, lstrip_blocks=True)
@@ -72,7 +74,6 @@ def main(_):
       pol_code=pol_code.strip(),
       unpol_code=unpol_code.strip(),
     )
-    py_code = post_process(py_code)
     with open(FLAGS.output, "w") as out:
       out.write(py_code)
 

--- a/maple2jax/impl/python_template.jinja
+++ b/maple2jax/impl/python_template.jinja
@@ -29,7 +29,8 @@ def invoke(
   deorbitalize: Optional[float] = None,
 ):
   args = rho_to_arguments(p, rho, r, mo, deorbitalize)
-  ret = pol(p, *args) if p.nspin == 2 else unpol(p, *args)
+  code = pol if p.nspin == 2 else unpol
   dens = args[0] if p.nspin == 1 else sum(args[0])
-  ret = lax.select((dens < p.dens_threshold), 0., ret)
+  ret = lax.cond((dens < p.dens_threshold), lambda *_: 0.,
+                 lambda *_: code(p, *args), None)
   return ret

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -21,3 +21,11 @@ py_test(
         "@maple2jax//jax_xc",
     ],
 )
+
+py_test(
+    name = "test_grad",
+    srcs = ["test_grad.py"],
+    deps = [
+        "@maple2jax//jax_xc",
+    ],
+)

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright 2022 Garena Online Private Limited
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import jax
+import jax.numpy as jnp
+import jax_xc
+from absl.testing import absltest, parameterized
+
+
+class _TestGrad(parameterized.TestCase):
+
+  def test_grad_is_not_nan(self):
+    """Test that the gradient of the functional is not nan."""
+    lda = jax_xc.lda_x(polarized=False)
+    r = jnp.array([[10., 10., 10.], [9, 9, 9]])
+
+    def rho(r):
+      return jnp.prod(jax.scipy.stats.norm.pdf(r, loc=0, scale=1))
+
+    def grad(r):
+      return jax.grad(lda, argnums=1)(rho, r)
+
+    g = jax.vmap(grad)(r)
+    self.assertFalse(jnp.isnan(g).any())
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
`lax.select` generates a `nan` in the gradient from the inactive branch, while `lax.cond` doesn't. According to the documentation, `lax.cond` will be converted to `lax.select` when `vmap` is applied, but it seems that the gradient of `lax.cond` and `lax.select` are implemented differently even when `vmap` is applied.