### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.9"
   commands:
     - pip install -r requirements.txt
     - pip install -r docs/requirements.txt


### PR DESCRIPTION
bump python version 3.8 to 3.9 for doc building as `autofd` requires python >= 3.9.

Doc building success in this branch.